### PR TITLE
Upload build script, ConsolidateArtifacts.bat, and update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,71 +1,71 @@
 [submodule "qtbase"]
 	path = qtbase
-	url = ../qtbase.git
+	url = https://github.com/qt/qtbase.git
 	branch = 5.6
 	status = essential
 [submodule "qtsvg"]
 	depends = qtbase
 	path = qtsvg
-	url = ../qtsvg.git
+	url = https://github.com/qt/qtsvg.git
 	branch = 5.6
 	status = addon
 [submodule "qtdeclarative"]
 	depends = qtbase
 	recommends = qtsvg qtxmlpatterns
 	path = qtdeclarative
-	url = ../qtdeclarative.git
+	url = https://github.com/qt/qtdeclarative.git
 	branch = 5.6
 	status = essential
 [submodule "qtactiveqt"]
 	depends = qtbase
 	path = qtactiveqt
-	url = ../qtactiveqt.git
+	url = https://github.com/qt/qtactiveqt.git
 	branch = 5.6
 	status = addon
 [submodule "qtscript"]
 	depends = qtbase
 	recommends = qttools
 	path = qtscript
-	url = ../qtscript.git
+	url = https://github.com/qt/qtscript.git
 	branch = 5.6
 	status = deprecated
 [submodule "qtmultimedia"]
 	depends = qtbase
 	recommends = qtdeclarative
 	path = qtmultimedia
-	url = ../qtmultimedia.git
+	url = https://github.com/qt/qtmultimedia.git
 	branch = 5.6
 	status = essential
 [submodule "qttools"]
 	depends = qtbase
 	recommends = qtdeclarative qtactiveqt qtwebkit
 	path = qttools
-	url = ../qttools.git
+	url = https://github.com/qt/qttools.git
 	branch = 5.6
 	status = essential
 [submodule "qtxmlpatterns"]
 	depends = qtbase
 	path = qtxmlpatterns
-	url = ../qtxmlpatterns.git
+	url = https://github.com/qt/qtxmlpatterns.git
 	branch = 5.6
 	status = addon
 [submodule "qttranslations"]
 	depends = qttools
 	path = qttranslations
-	url = ../qttranslations.git
+	url = https://github.com/qt/qttranslations.git
 	branch = 5.6
 	status = essential
 	priority = 30
 [submodule "qtdoc"]
 	depends = qtdeclarative
 	path = qtdoc
-	url = ../qtdoc.git
+	url = https://github.com/qt/qtdoc.git
 	branch = 5.6
 	status = essential
 	priority = 40
 [submodule "qtrepotools"]
 	path = qtrepotools
-	url = ../qtrepotools.git
+	url = https://github.com/qt/qtrepotools.git
 	branch = master
 	status = essential
 	project = -
@@ -74,7 +74,7 @@
 	recommends = qtdeclarative qtlocation qtmultimedia qtsensors qtwebchannel qtxmlpatterns
 	serialize = qtwebengine
 	path = qtwebkit
-	url = ../qtwebkit.git
+	url = https://github.com/qt/qtwebkit.git
 	branch = 5.6
 	status = obsolete
 	project = WebKit.pro
@@ -82,13 +82,13 @@
 [submodule "qtwebkit-examples"]
 	depends = qtwebkit qttools
 	path = qtwebkit-examples
-	url = ../qtwebkit-examples.git
+	url = https://github.com/qt/qtwebkit-examples.git
 	branch = 5.6
 	status = obsolete
 [submodule "qtqa"]
 	depends = qtbase
 	path = qtqa
-	url = ../qtqa.git
+	url = https://github.com/qt/qtqa.git
 	branch = master
 	status = essential
 	priority = 50
@@ -96,176 +96,176 @@
 	depends = qtbase
 	recommends = qtdeclarative qtquickcontrols qtserialport qtsystems
 	path = qtlocation
-	url = ../qtlocation.git
+	url = https://github.com/qt/qtlocation.git
 	branch = 5.6
 	status = addon
 [submodule "qtsensors"]
 	depends = qtbase
 	recommends = qtdeclarative
 	path = qtsensors
-	url = ../qtsensors.git
+	url = https://github.com/qt/qtsensors.git
 	branch = 5.6
 	status = addon
 [submodule "qtsystems"]
 	depends = qtbase
 	recommends = qtdeclarative
 	path = qtsystems
-	url = ../qtsystems.git
+	url = https://github.com/qt/qtsystems.git
 	branch = dev
 	status = ignore
 [submodule "qtfeedback"]
 	depends = qtdeclarative
 	recommends = qtmultimedia
 	path = qtfeedback
-	url = ../qtfeedback.git
+	url = https://github.com/qt/qtfeedback.git
 	branch = master
 	status = ignore
 [submodule "qtdocgallery"]
 	depends = qtdeclarative
 	path = qtdocgallery
-	url = ../qtdocgallery.git
+	url = https://github.com/qt/qtdocgallery.git
 	branch = master
 	status = ignore
 [submodule "qtpim"]
 	depends = qtdeclarative
 	path = qtpim
-	url = ../qtpim.git
+	url = https://github.com/qt/qtpim.git
 	branch = dev
 	status = ignore
 [submodule "qtconnectivity"]
 	depends = qtbase
 	recommends = qtdeclarative qtandroidextras
 	path = qtconnectivity
-	url = ../qtconnectivity.git
+	url = https://github.com/qt/qtconnectivity.git
 	branch = 5.6
 	status = addon
 [submodule "qtwayland"]
 	depends = qtbase
 	recommends = qtdeclarative
 	path = qtwayland
-	url = ../qtwayland.git
+	url = https://github.com/qt/qtwayland.git
 	branch = 5.6
 	status = addon
 [submodule "qt3d"]
 	depends = qtdeclarative qtimageformats
 	path = qt3d
-	url = ../qt3d.git
+	url = https://github.com/qt/qt3d.git
 	branch = 5.6
 	status = preview
 [submodule "qtimageformats"]
 	depends = qtbase
 	path = qtimageformats
-	url = ../qtimageformats.git
+	url = https://github.com/qt/qtimageformats.git
 	branch = 5.6
 	status = addon
 [submodule "qtquick1"]
 	depends = qtscript
 	recommends = qtsvg qtxmlpatterns
 	path = qtquick1
-	url = ../qtquick1.git
+	url = https://github.com/qt/qtquick1.git
 	branch = 5.6
 	status = obsolete
 [submodule "qtgraphicaleffects"]
 	depends = qtdeclarative
 	path = qtgraphicaleffects
-	url = ../qtgraphicaleffects.git
+	url = https://github.com/qt/qtgraphicaleffects.git
 	branch = 5.6
 	status = addon
 [submodule "qtquickcontrols"]
 	depends = qtdeclarative
 	recommends = qtgraphicaleffects
 	path = qtquickcontrols
-	url = ../qtquickcontrols.git
+	url = https://github.com/qt/qtquickcontrols.git
 	branch = 5.6
 	status = essential
 [submodule "qtserialbus"]
 	depends = qtserialport
 	path = qtserialbus
-	url = ../qtserialbus.git
+	url = https://github.com/qt/qtserialbus.git
 	branch = 5.6
 	status = preview
 [submodule "qtserialport"]
 	depends = qtbase
 	path = qtserialport
-	url = ../qtserialport.git
+	url = https://github.com/qt/qtserialport.git
 	branch = 5.6
 	status = addon
 [submodule "qtx11extras"]
 	depends = qtbase
 	path = qtx11extras
-	url = ../qtx11extras.git
+	url = https://github.com/qt/qtx11extras.git
 	branch = 5.6
 	status = addon
 [submodule "qtmacextras"]
 	depends = qtbase
 	path = qtmacextras
-	url = ../qtmacextras.git
+	url = https://github.com/qt/qtmacextras.git
 	branch = 5.6
 	status = addon
 [submodule "qtwinextras"]
 	depends = qtbase
 	recommends = qtdeclarative qtmultimedia
 	path = qtwinextras
-	url = ../qtwinextras.git
+	url = https://github.com/qt/qtwinextras.git
 	branch = 5.6
 	status = addon
 [submodule "qtandroidextras"]
 	depends = qtbase
 	path = qtandroidextras
-	url = ../qtandroidextras.git
+	url = https://github.com/qt/qtandroidextras.git
 	branch = 5.6
 	status = addon
 [submodule "qtenginio"]
 	depends = qtdeclarative
 	path = qtenginio
-	url = ../qtenginio.git
+	url = https://github.com/qt/qtenginio.git
 	branch = 5.6
 	status = deprecated
 [submodule "qtwebsockets"]
 	depends = qtbase
 	recommends = qtdeclarative
 	path = qtwebsockets
-	url = ../qtwebsockets.git
+	url = https://github.com/qt/qtwebsockets.git
 	branch = 5.6
 	status = addon
 [submodule "qtwebchannel"]
 	depends = qtbase
 	recommends = qtdeclarative qtwebsockets
 	path = qtwebchannel
-	url = ../qtwebchannel.git
+	url = https://github.com/qt/qtwebchannel.git
 	branch = 5.6
 	status = addon
 [submodule "qtwebengine"]
 	depends = qtquickcontrols qtwebchannel
 	recommends = qtlocation
 	path = qtwebengine
-	url = ../qtwebengine.git
+	url = https://github.com/qt/qtwebengine.git
 	branch = 5.6
 	status = addon
 	priority = 10
 [submodule "qtcanvas3d"]
 	depends = qtdeclarative
 	path = qtcanvas3d
-	url = ../qtcanvas3d.git
+	url = https://github.com/qt/qtcanvas3d.git
 	branch = 5.6
 	status = addon
 [submodule "qtwebview"]
 	depends = qtdeclarative
 	recommends = qtwebengine
 	path = qtwebview
-	url = ../qtwebview.git
+	url = https://github.com/qt/qtwebview.git
 	branch = 5.6
 	status = addon
 [submodule "qtquickcontrols2"]
 	depends = qtquickcontrols
 	path = qtquickcontrols2
-	url = ../qtquickcontrols2.git
+	url = https://github.com/qt/qtquickcontrols2.git
 	branch = 5.6
 	status = preview
 [submodule "qtpurchasing"]
 	depends = qtbase qtandroidextras
 	recommends = qtdeclarative
 	path = qtpurchasing
-	url = ../qtpurchasing.git
+	url = https://github.com/qt/qtpurchasing.git
 	branch = dev
 	status = ignore

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -21,7 +21,7 @@ mkdir %OUT_DIR%\%BUILD_ID%
 if !errorlevel! neq 0 exit /b !errorlevel!
 pushd %OUT_DIR%\%BUILD_ID%
 if !errorlevel! neq 0 exit /b !errorlevel!
-call ..\configure -static -prefix %BUILD_ID% -platform %QMAKESPEC% -debug-and-release -confirm-license -opensource -opengl desktop -static -mp -qt-zlib -qt-pcre -qt-freetype -qt-libpng -qt-libjpeg -direct2d -qt-harfbuzz -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdeclarative -skip qtdoc -skip qtenginio -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtquickcontrols -skip qtscript -skip qtsensors -skip qtserialport -skip qtsvg -skip qttools -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns -nomake examples -nomake tools -nomake tests
+call ..\..\configure -static -prefix %BUILD_ID% -platform %QMAKESPEC% -debug-and-release -confirm-license -opensource -opengl desktop -static -mp -qt-zlib -qt-pcre -qt-freetype -qt-libpng -qt-libjpeg -direct2d -qt-harfbuzz -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdeclarative -skip qtdoc -skip qtenginio -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtquickcontrols -skip qtscript -skip qtsensors -skip qtserialport -skip qtsvg -skip qttools -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns -nomake examples -nomake tools -nomake tests
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 CALL jom.exe /j 8 install

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -6,7 +6,7 @@ rem The script assumed that perl, jom and python are already set in PATH. The ou
 SET OUT_DIR=Qt
 SET SRC_DIR=.
 SET BUILD_ID=x64-msvc2015-static
-SET QMAKESPEC=winrt-x64-msvc2015
+SET QMAKESPEC=x64-msvc2015
 
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -1,0 +1,23 @@
+rem The script assumed that perl, jom and python are already set in PATH. The output dir will be Qt
+@SETLOCAL
+@ECHO OFF
+SET OUT_DIR=Qt
+SET SRC_DIR=.
+SET BUILD_ID=x64-msvc2015-static
+SET QMAKESPEC=winrt-x64-msvc2015
+
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
+
+SET PATH=%SRC_DIR%\qtbase\bin;%SRC_DIR%\gnuwin32\bin;%PATH%
+SET PATH=%SRC_DIR%\qtrepotools\bin;%PATH%
+
+
+@ECHO ON
+git submodule update --init --recursive
+call perl init-repository -f
+mkdir %OUT_DIR%
+pushd %OUT_DIR%
+call ..\configure -static -prefix %BUILD_ID% -platform %QMAKESPEC% -debug-and-release -confirm-license -opensource -opengl desktop -static -mp -qt-zlib -qt-pcre -qt-freetype -qt-libpng -qt-libjpeg -direct2d -qt-harfbuzz -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdeclarative -skip qtdoc -skip qtenginio -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtquickcontrols -skip qtscript -skip qtsensors -skip qtserialport -skip qtsvg -skip qttools -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns -nomake examples -nomake tools -nomake tests
+
+CALL jom.exe /j 8 install
+@ECHO OFF

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -1,4 +1,4 @@
-rem The script assumed that perl, jom and python are already set in PATH. The output dir will be Qt
+rem The script assumed that perl, jom and python are already set in PATH. The output dir will be Qt\[BUILD_ID]
 @SETLOCAL
 @ECHO OFF
 SET OUT_DIR=Qt
@@ -15,8 +15,8 @@ SET PATH=%SRC_DIR%\qtrepotools\bin;%PATH%
 @ECHO ON
 git submodule update --init --recursive
 call perl init-repository -f
-mkdir %OUT_DIR%
-pushd %OUT_DIR%
+mkdir %OUT_DIR%\%BUILD_ID%
+pushd %OUT_DIR%\%BUILD_ID%
 call ..\configure -static -prefix %BUILD_ID% -platform %QMAKESPEC% -debug-and-release -confirm-license -opensource -opengl desktop -static -mp -qt-zlib -qt-pcre -qt-freetype -qt-libpng -qt-libjpeg -direct2d -qt-harfbuzz -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdeclarative -skip qtdoc -skip qtenginio -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtquickcontrols -skip qtscript -skip qtsensors -skip qtserialport -skip qtsvg -skip qttools -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns -nomake examples -nomake tools -nomake tests
 
 CALL jom.exe /j 8 install

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -6,7 +6,7 @@ rem The script assumed that perl, jom and python are already set in PATH. The ou
 SET OUT_DIR=Qt
 SET SRC_DIR=.
 SET BUILD_ID=x64-msvc2015-static
-SET QMAKESPEC=x64-msvc2015
+SET QMAKESPEC=winrt-x64-msvc2015
 
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -6,7 +6,7 @@ rem The script assumed that perl, jom and python are already set in PATH. The ou
 SET OUT_DIR=Qt
 SET SRC_DIR=.
 SET BUILD_ID=x64-msvc2015-static
-SET QMAKESPEC=winrt-x64-msvc2015
+SET QMAKESPEC=win32-msvc2015
 
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
 if !errorlevel! neq 0 exit /b !errorlevel!

--- a/BUILD_QT.bat
+++ b/BUILD_QT.bat
@@ -1,3 +1,5 @@
+setlocal EnableDelayedExpansion
+
 rem The script assumed that perl, jom and python are already set in PATH. The output dir will be Qt\[BUILD_ID]
 @SETLOCAL
 @ECHO OFF
@@ -7,17 +9,23 @@ SET BUILD_ID=x64-msvc2015-static
 SET QMAKESPEC=winrt-x64-msvc2015
 
 call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
+if !errorlevel! neq 0 exit /b !errorlevel!
 
 SET PATH=%SRC_DIR%\qtbase\bin;%SRC_DIR%\gnuwin32\bin;%PATH%
 SET PATH=%SRC_DIR%\qtrepotools\bin;%PATH%
 
-
 @ECHO ON
-git submodule update --init --recursive
 call perl init-repository -f
+if !errorlevel! neq 0 exit /b !errorlevel!
 mkdir %OUT_DIR%\%BUILD_ID%
+if !errorlevel! neq 0 exit /b !errorlevel!
 pushd %OUT_DIR%\%BUILD_ID%
+if !errorlevel! neq 0 exit /b !errorlevel!
 call ..\configure -static -prefix %BUILD_ID% -platform %QMAKESPEC% -debug-and-release -confirm-license -opensource -opengl desktop -static -mp -qt-zlib -qt-pcre -qt-freetype -qt-libpng -qt-libjpeg -direct2d -qt-harfbuzz -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtconnectivity -skip qtdeclarative -skip qtdoc -skip qtenginio -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtquickcontrols -skip qtscript -skip qtsensors -skip qtserialport -skip qtsvg -skip qttools -skip qttranslations -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwinextras -skip qtx11extras -skip qtxmlpatterns -nomake examples -nomake tools -nomake tests
+if !errorlevel! neq 0 exit /b !errorlevel!
 
 CALL jom.exe /j 8 install
+if !errorlevel! neq 0 exit /b !errorlevel!
 @ECHO OFF
+
+exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -20,5 +20,9 @@ xcopy "%static_lib_path%\plugins"  "%destination%\plugins" /y/s/q/i
 
 REM remove all intermediate files in the original library folder
 rmdir "%lib_path%" /s /q
+pushd "%destination%"
+rmdir "lib\cmake" /s /q
+del *.prl /s /q
+del *.pdb /s /q
 
 exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -19,6 +19,6 @@ xcopy "%static_lib_path%\bin"  "%destination%\bin" /y/s/q/i
 xcopy "%static_lib_path%\plugins"  "%destination%\plugins" /y/s/q/i
 
 REM remove all intermediate files in the original library folder
-rmdir %lib_path% /s /q
+rmdir "%lib_path%" /s /q
 
 exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -25,4 +25,9 @@ rmdir "lib\cmake" /s /q
 del *.prl /s /q
 del *.pdb /s /q
 
+pushd bin
+REM delete all applications except for necessary ones.
+for %i in (*.*) do if not "%i"=="moc.exe" if not "%i"=="rcc.exe" if not "%i"=="uic.exe" del /q "%i"
+
+
 exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -35,7 +35,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 
 pushd bin
 REM delete all applications except for necessary ones.
-for %i in (*.*) do if not "%i"=="moc.exe" if not "%i"=="rcc.exe" if not "%i"=="uic.exe" del /q "%i"
+for %%i in (*.*) do if not "%%i"=="moc.exe" if not "%%i"=="rcc.exe" if not "%%i"=="uic.exe" del /q "%%i"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -28,14 +28,14 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 pushd "%destination%"
 rmdir "lib\cmake" /s /q
 if !errorlevel! neq 0 exit /b !errorlevel!
-del *.prl /s /q
+del *.prl /s /q /f
 if !errorlevel! neq 0 exit /b !errorlevel!
-del *.pdb /s /q
+del *.pdb /s /q /f
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 pushd bin
 REM delete all applications except for necessary ones.
-for %%i in (*.*) do if not "%%i"=="moc.exe" if not "%%i"=="rcc.exe" if not "%%i"=="uic.exe" del /q "%%i"
+for %%i in (*.*) do if not "%%i"=="moc.exe" if not "%%i"=="rcc.exe" if not "%%i"=="uic.exe" del /q /f "%%i"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 exit /b 0

--- a/ConsolidateArtifacts.bat
+++ b/ConsolidateArtifacts.bat
@@ -1,0 +1,24 @@
+setlocal EnableDelayedExpansion
+
+echo off
+
+set destination=artifacts
+set staticConfig=static
+set dynamicConfig=dynamic
+set platform=x64
+set msvcVersion=msvc2015
+set lib_path=Qt\%platform%-%msvcVersion%-%staticConfig%
+set static_lib_path=%lib_path%\qtbase\bin\%platform%-%msvcVersion%-%staticConfig%
+
+if exist "%destination%" rmdir "%destination%" /s/q
+
+echo "Packaging library"
+xcopy "%static_lib_path%\include"  "%destination%\include" /y/s/q/i
+xcopy "%static_lib_path%\lib"  "%destination%\lib" /y/s/q/i
+xcopy "%static_lib_path%\bin"  "%destination%\bin" /y/s/q/i
+xcopy "%static_lib_path%\plugins"  "%destination%\plugins" /y/s/q/i
+
+REM remove all intermediate files in the original library folder
+rmdir %lib_path% /s /q
+
+exit /b 0


### PR DESCRIPTION
1. Updated the .gitmoduels so that all the submodules link to the qt submodules.
Please run "git submodule sync" to maker sure it is synchronized correctly.
2. Upload the build script: the build script assumes that python, perl, and jom are already added to PATH.
The script will build qt static library for winrt-x64-msvc2015. The output library will be in Qt\qtbase\
3. Added ConsolidateArtifacts.bat. The script will copy minimum set of the library to .\artifacts and remove all other intermediate files.