### PR TITLE
Fix/use win32 for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "binary": {
     "file": "{package_name}/{package_version}/qt5-{package_version}-{platform}-{arch}.tar.gz",
     "host": "https://registry-node.starbreeze.com/-/releases",
-    "os": "Windows",
+    "os": "win32",
     "path": [
       "artifacts",
       "artifacts/**"


### PR DESCRIPTION
because of 
ERR! os win32 disabled by package.json
http://50.250.211.65:7070/job/build-qt5-on-windows/19/console